### PR TITLE
駒の動きにより次以降の動きをフィルタ

### DIFF
--- a/src/main/java/quantumshogi/Controller.kt
+++ b/src/main/java/quantumshogi/Controller.kt
@@ -1,6 +1,7 @@
 package quantumshogi
 
 import javafx.beans.binding.Bindings
+import javafx.beans.binding.BooleanBinding
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
 import javafx.fxml.FXML
@@ -30,7 +31,7 @@ class Controller : Initializable {
                 val square = Chessboard[place]
                 val stackPane = StackPane().apply {
                     alignment = Pos.CENTER
-                    styleProperty().bind(Bindings.createStringBinding(Callable {
+                    styleProperty().bind(Bindings.createStringBinding(Callable{
                         if (square.enterableProperty.value) {
                             return@Callable "-fx-background-color:#ff0000a0"
                         }

--- a/src/main/java/quantumshogi/chessboard/Chessboard.kt
+++ b/src/main/java/quantumshogi/chessboard/Chessboard.kt
@@ -2,6 +2,7 @@ package quantumshogi.chessboard
 
 import javafx.scene.control.Alert
 import javafx.scene.control.ButtonType
+import quantumshogi.pieces.PieceType
 import quantumshogi.pieces.QuantumPiece
 import quantumshogi.place.Place
 import quantumshogi.player.Player
@@ -20,17 +21,24 @@ object Chessboard {
             return false
         }
 
+        val before = toModel()
+
         val (y, x) = Chessboard.selected
         val selectedSquare = Chessboard.get(x, y)
         Chessboard.get(to.file, to.rank).piece = selectedSquare.piece
         selectedSquare.piece = null
 
         Chessboard.clearEnterable()
-        playing = playing.nextPlayer
-        status = Status.IDLE
 
         rows.filter { it.piece != null }.forEach { it.piece!!.place = it.place }
 
+        val cloned = Chessboard.get(to.file, to.rank).piece!!.possibles.toList()
+        val filtered = cloned.filter { it.movements(selected, playing, before).contains(to) }
+        println(PieceType.GOLD.movements(selected, playing, before))
+        println("$cloned -> $filtered")
+
+        Chessboard.get(to.file, to.rank).piece!!.possibles.clear()
+        Chessboard.get(to.file, to.rank).piece!!.possibles.addAll(filtered)
 
         if (Chessboard.get(to.file, to.rank).piece!!.possibles.any { it.canPromote }) {
             if (to.rank in playing.promotableRank) {
@@ -43,6 +51,8 @@ object Chessboard {
             }
         }
 
+        playing = playing.nextPlayer
+        status = Status.IDLE
         println(Chessboard.toModel())
         return true
     }

--- a/src/main/java/quantumshogi/chessboard/Square.kt
+++ b/src/main/java/quantumshogi/chessboard/Square.kt
@@ -1,5 +1,6 @@
 package quantumshogi.chessboard
 
+import javafx.application.Platform
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import quantumshogi.pieces.Piece
@@ -10,17 +11,17 @@ class Square(
         var place: Place
 ) {
     val hasPieceProperty = SimpleBooleanProperty(false)
-    val pieceProperty = SimpleObjectProperty(piece)
+    val pieceProperty = SimpleObjectProperty(piece).apply {
+        addListener { _, _, _ -> }
+    }
     val enterableProperty = SimpleBooleanProperty(false)
     var piece: Piece? = null
         set(value) {
             field = value
-            if (value == null) {
-                hasPieceProperty.value = false
-                return
+            Platform.runLater {
+                hasPieceProperty.value = value != null
+                pieceProperty.value = value
             }
-            hasPieceProperty.value = true
-            pieceProperty.value = value
         }
 
     init {

--- a/src/main/java/quantumshogi/pieces/QuantumPiece.kt
+++ b/src/main/java/quantumshogi/pieces/QuantumPiece.kt
@@ -9,13 +9,13 @@ class QuantumPiece(
         override var place: Place
 ) : Piece {
     override val possibles: MutableList<PieceType> = mutableListOf(
-            //if (player == Player.BLACK) PieceType.KING_HIGHER_RANKED_PLAYER else PieceType.KING_LOWER_RANKED_PLAYER,
-            //PieceType.ROOK,
+            if (player == Player.WHITE) PieceType.KING_HIGHER_RANKED_PLAYER else PieceType.KING_LOWER_RANKED_PLAYER,
+            PieceType.ROOK,
             PieceType.BISHOP,
-            //PieceType.GOLD,
-            //PieceType.SILVER,
-            //PieceType.KNIGHT,
-            //PieceType.LANCE,
+            PieceType.GOLD,
+            PieceType.SILVER,
+            PieceType.KNIGHT,
+            PieceType.LANCE,
             PieceType.PAWN
     )
     override val playerProperty = SimpleObjectProperty(player)

--- a/src/main/java/quantumshogi/player/Player.kt
+++ b/src/main/java/quantumshogi/player/Player.kt
@@ -2,7 +2,7 @@ package quantumshogi.player
 
 enum class Player(val direction: Int, val color: String, val char: String) {
     BLACK(1, "#000000", "☗") {
-        override val promotableRank = 0..2
+        override val promotableRank = 6..8
 
         override val forward by lazy { Movement(1, 0) }
         override val backward by lazy { Movement(-1, 0) }
@@ -17,7 +17,7 @@ enum class Player(val direction: Int, val color: String, val char: String) {
     },
 
     WHITE(-1, "#FFFFFF", "☖") {
-        override val promotableRank = 6..8
+        override val promotableRank = 0..2
 
         override val forward by lazy { Movement(-1, 0) }
         override val backward by lazy { Movement(1, 0) }


### PR DESCRIPTION
TODO:
持ち駒数で制限する

Merge remote-tracking branch 'remotes/upstream/Viewの分離' into add_promotion

# Conflicts:
#	src/main/java/quantumshogi/Controller.kt